### PR TITLE
⚡ Parallelize independent global data fetching in Layout

### DIFF
--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -23,33 +23,34 @@ export default async function Layout({ children, rawPageData }: LayoutProps) {
   let globalSharedData;
 
   try {
-    // Fetch locale-specific global content (no fallback needed)
-    globalData = await client.queries.global(
-      {
-        relativePath: `${locale}/index.json`,
-      },
-      {
-        fetchOptions: {
-          next: {
-            revalidate: 60,
+    [globalData, globalSharedData] = await Promise.all([
+      // Fetch locale-specific global content (no fallback needed)
+      client.queries.global(
+        {
+          relativePath: `${locale}/index.json`,
+        },
+        {
+          fetchOptions: {
+            next: {
+              revalidate: 60,
+            },
           },
         },
-      },
-    );
-
-    // Fetch shared global content (not locale-specific)
-    globalSharedData = await client.queries.globalShared(
-      {
-        relativePath: 'index.json',
-      },
-      {
-        fetchOptions: {
-          next: {
-            revalidate: 60,
+      ),
+      // Fetch shared global content (not locale-specific)
+      client.queries.globalShared(
+        {
+          relativePath: 'index.json',
+        },
+        {
+          fetchOptions: {
+            next: {
+              revalidate: 60,
+            },
           },
         },
-      },
-    );
+      ),
+    ]);
   } catch (error) {
     // If either global or contact data fails to load, throw error
     throw error;


### PR DESCRIPTION
### 💡 **What:** 
Refactored sequential `await` calls for `globalData` and `globalSharedData` in the `Layout` component into a single `Promise.all` call.

### 🎯 **Why:** 
The two GraphQL queries `client.queries.global` and `client.queries.globalShared` do not depend on each other. Fetching them sequentially introduced an unnecessary network round-trip delay. Parallelizing them reduces the total data fetching time from the sum of both request times (T1 + T2) to the maximum of the two (max(T1, T2)).

### 📊 **Measured Improvement:** 
Live benchmarking was impractical due to the absence of the generated TinaCMS client and necessary environment variables in the sandbox. However, the theoretical improvement is a reduction in network latency for these requests. This change aligns with existing best practices already implemented in other parts of the codebase, such as `app/[locale]/page.tsx`.

---
*PR created automatically by Jules for task [5876447241122549104](https://jules.google.com/task/5876447241122549104) started by @daribock*