### PR TITLE
feat: add dark mode toggle with theme provider and i18n support

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { OrganizationStructuredData } from '@/components/structured-data';
 
 import '@/styles.css';
 import { TailwindIndicator } from '@/components/ui/breakpoint-indicator';
+import { ThemeProvider } from '@/components/ui/theme-provider';
 
 import { NextIntlClientProvider, hasLocale } from 'next-intl';
 import { notFound } from 'next/navigation';
@@ -72,6 +73,7 @@ export default async function RootLayout({
   return (
     <html
       lang={locale}
+      suppressHydrationWarning
       className={cn(fontSans.variable, nunito.variable, lato.variable)}
     >
       <head>
@@ -82,11 +84,13 @@ export default async function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
-        <NextIntlClientProvider>{children}</NextIntlClientProvider>
-        <TailwindIndicator />
-        <SpeedInsights />
-        <Analytics />
-        <Toaster />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <NextIntlClientProvider>{children}</NextIntlClientProvider>
+          <TailwindIndicator />
+          <SpeedInsights />
+          <Analytics />
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/components/layout/nav/header.tsx
+++ b/components/layout/nav/header.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { useLayout } from '../layout-context';
 import { Menu, X } from 'lucide-react';
 import LocaleSwitcher from './locale-switcher';
+import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { cn } from '@/lib/utils';
 
 export const Header = () => {
@@ -22,7 +23,7 @@ export const Header = () => {
     <header>
       <nav
         data-state={menuState && 'active'}
-        className="bg-white/95 backdrop-blur-md border-b fixed z-20 w-full  h-16"
+        className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-md border-b fixed z-20 w-full  h-16"
       >
         <div className="mx-auto max-w-6xl px-6 h-full">
           <div className="relative flex items-center justify-between h-full">
@@ -35,6 +36,15 @@ export const Header = () => {
                   alt="Logo"
                   width={40}
                   height={40}
+                  loading="eager"
+                  className="dark:hidden"
+                />
+                <Image
+                  src="/uploads/logos/logo-transparent-weiss.png"
+                  alt="Logo"
+                  width={40}
+                  height={40}
+                  className="hidden dark:block"
                 />
               </Link>
 
@@ -55,12 +65,13 @@ export const Header = () => {
               </div>
             </div>
 
-            {/* Right side: Language Switcher + Site Name */}
-            {process.env.NEXT_PUBLIC_ENABLE_LOCALE_SWITCHER === 'true' && (
-              <div className="hidden lg:flex items-center gap-4 h-full">
+            {/* Right side: Language Switcher + Theme Toggle */}
+            <div className="hidden lg:flex items-center gap-2 h-full">
+              {process.env.NEXT_PUBLIC_ENABLE_LOCALE_SWITCHER === 'true' && (
                 <LocaleSwitcher className="border-none" />
-              </div>
-            )}
+              )}
+              <ThemeToggle />
+            </div>
 
             {/* Mobile menu button */}
             <button
@@ -93,12 +104,13 @@ export const Header = () => {
                   ))}
                 </ul>
 
-                {/* Mobile Language Switcher & Site Name */}
-                {process.env.NEXT_PUBLIC_ENABLE_LOCALE_SWITCHER === 'true' && (
-                  <div className="flex items-center justify-between pt-4 border-t">
+                {/* Mobile Language Switcher & Theme Toggle */}
+                <div className="flex items-center justify-between pt-4 border-t">
+                  {process.env.NEXT_PUBLIC_ENABLE_LOCALE_SWITCHER === 'true' && (
                     <LocaleSwitcher />
-                  </div>
-                )}
+                  )}
+                  <ThemeToggle />
+                </div>
               </div>
             </div>
           </div>

--- a/components/ui/theme-provider.tsx
+++ b/components/ui/theme-provider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import * as React from 'react';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import * as React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, setTheme } = useTheme();
+  const t = useTranslations('ThemeToggle');
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" className={className} aria-label={t('switchToDark')}>
+        <Sun className="size-5" />
+      </Button>
+    );
+  }
+
+  const isDark = theme === 'dark';
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={className}
+      aria-label={isDark ? t('switchToLight') : t('switchToDark')}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+    >
+      {isDark ? (
+        <Sun className="size-5" />
+      ) : (
+        <Moon className="size-5" />
+      )}
+    </Button>
+  );
+}

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -42,5 +42,9 @@
     "copyright": "© {year} Betania Ingolstadt. Alle Rechte vorbehalten.",
     "dataPrivacy": "Datenschutz",
     "imprint": "Impressum"
+  },
+  "ThemeToggle": {
+    "switchToDark": "Zu Dunkelmodus wechseln",
+    "switchToLight": "Zu Hellmodus wechseln"
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -42,5 +42,9 @@
     "copyright": "© {year} Betania Ingolstadt. All rights reserved.",
     "dataPrivacy": "Privacy Policy",
     "imprint": "Imprint"
+  },
+  "ThemeToggle": {
+    "switchToDark": "Switch to dark mode",
+    "switchToLight": "Switch to light mode"
   }
 }

--- a/i18n/locales/ro.json
+++ b/i18n/locales/ro.json
@@ -42,5 +42,9 @@
     "copyright": "© {year} Betania Ingolstadt. Toate drepturile rezervate.",
     "dataPrivacy": "Confidențialitate",
     "imprint": "Impresii"
+  },
+  "ThemeToggle": {
+    "switchToDark": "Comutați la modul întunecat",
+    "switchToLight": "Comutați la modul luminos"
   }
 }


### PR DESCRIPTION
- Add ThemeProvider wrapping the app layout with system default
- Add ThemeToggle component to header (desktop and mobile)
- Show light/dark logo variants based on active theme
- Apply dark mode styles to header background
- Add ThemeToggle translations for de, en, and ro locales