### PR TITLE
🎨 Palette: Add ARIA labels to social links and hide honeypot field

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-01 - Missing ARIA Labels on Dynamically Generated Social Links
+**Learning:** In dynamically generated icon-only link lists (like social links in a footer), the `aria-label` is often overlooked because the visible component is an abstract `<Icon />` that doesn't inherently contain text. Screen readers encounter an empty link.
+**Action:** When mapping over dynamic data to create icon-only links, always ensure the data source includes a name/label field and explicitly apply it as an `aria-label` to the wrapping anchor tag.

--- a/components/contact-form-fields.tsx
+++ b/components/contact-form-fields.tsx
@@ -45,6 +45,7 @@ export const ContactFormFields = ({ form, onSubmit, loading, data }: ContactForm
               style={{ display: 'none' }}
               tabIndex={-1}
               autoComplete="off"
+              aria-hidden="true"
             />
           )}
         />

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -143,6 +143,7 @@ export const Footer = () => {
                   href={link!.url!}
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label={link!.icon?.name ? `Visit our ${link!.icon.name} page` : 'Social Media Link'}
                   className="text-gray-400 hover:text-white transition-colors"
                 >
                   <Icon


### PR DESCRIPTION
💡 What: Added `aria-label` to dynamically generated icon-only social links in the footer, and `aria-hidden="true"` to the honeypot bot field in the contact form. Created `.Jules/palette.md` to record the UX learning.
🎯 Why: The social links previously rendered an `<Icon />` without an accessible name, making them empty links for screen reader users. The honeypot field is visually hidden using CSS but needs `aria-hidden` to explicitly hide it from assistive technologies.
♿ Accessibility: Improved screen reader navigation in the footer and contact form.

---
*PR created automatically by Jules for task [14896705457453309851](https://jules.google.com/task/14896705457453309851) started by @daribock*