### PR TITLE
⚡ Bolt: Lazy load events iframe

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-01 - [Iframe Lazy Loading]
+**Learning:** Missing comments for performance optimization was flagged during Code Review.
+**Action:** Always ensure to explicitly add a comment like `// ⚡ Bolt: ...` around the optimization logic to fulfill the rule requirement.

--- a/components/blocks/events.tsx
+++ b/components/blocks/events.tsx
@@ -17,10 +17,13 @@ export const Events = ({ data }: { data: PageBlocksEvents }) => {
 
       <Card className="mt-8 w-full flex justify-center">
         <div className="w-full aspect-video">
+          {/* ⚡ Bolt: Lazy load the iframe to improve initial page load performance and reduce main thread blocking. */}
           <iframe
             className="w-full h-full border-0"
             data-tina-field={tinaField(data, 'churchToolsLink')}
             src={data.churchToolsLink || ''}
+            loading="lazy"
+            title="Events calendar"
           ></iframe>
         </div>
       </Card>


### PR DESCRIPTION
💡 What: Added `loading="lazy"` and a `title` to the iframe in the `Events` component.
🎯 Why: The iframe loads ChurchTools widgets which contain scripts, styles, and API requests that block the main thread and impact initial page load metrics (LCP, TBT).
📊 Impact: Expected to reduce initial main thread blocking and save bandwidth until the user scrolls down to the Events section.
🔬 Measurement: Verify with Lighthouse/PageSpeed Insights or network tab when loading a page with the Events block.

---
*PR created automatically by Jules for task [8260008581542223044](https://jules.google.com/task/8260008581542223044) started by @daribock*