### PR TITLE
🎨 Palette: Improve accessibility of mobile menu toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-03 - [Mobile Menu Accessibility]
+**Learning:** Found the mobile menu toggle button in `components/layout/nav/header.tsx` was missing critical accessibility attributes like `aria-expanded` and `aria-controls`. This pattern of interactive toggles without explicit screen reader communication was present.
+**Action:** Applied standard `aria-expanded` dynamically tied to state and paired it with `aria-controls` referencing an added ID on the target container. Future interactive toggles in this app should explicitly establish relationship and state through ARIA attributes.

--- a/components/layout/nav/header.tsx
+++ b/components/layout/nav/header.tsx
@@ -67,6 +67,8 @@ export const Header = () => {
             <button
               onClick={() => setMenuState(!menuState)}
               aria-label={menuState ? 'Close Menu' : 'Open Menu'}
+              aria-expanded={menuState}
+              aria-controls="mobile-menu"
               className="relative z-20 -m-2.5 -mr-4 block cursor-pointer p-2.5 lg:hidden h-12 w-12 flex items-center justify-center"
             >
               <Menu className="in-data-[state=active]:rotate-180 in-data-[state=active]:scale-0 in-data-[state=active]:opacity-0 m-auto size-6 duration-200" />
@@ -75,6 +77,7 @@ export const Header = () => {
 
             {/* Mobile navigation menu */}
             <div
+              id="mobile-menu"
               className={cn(
                 'bg-background z-20 in-data-[state=active]:block lg:in-data-[state=active]:flex mb-6 hidden w-full flex-wrap items-center justify-end space-y-8 rounded-xl border p-6 shadow-2xl shadow-zinc-300/20 md:flex-nowrap lg:m-0 lg:hidden lg:w-fit lg:gap-6 lg:space-y-0 lg:border-transparent lg:bg-transparent lg:p-0 lg:shadow-none dark:shadow-none dark:lg:bg-transparent absolute top-16 left-0 right-0',
               )}


### PR DESCRIPTION
💡 **What**: Added `aria-expanded` and `aria-controls` to the mobile menu toggle button, and explicitly gave the menu container `id="mobile-menu"`.
🎯 **Why**: Previously, the mobile menu toggle button did not communicate its open/closed state to screen readers.
♿ **Accessibility**: Significant improvement for screen reader users by clearly defining the element's state and relationship to the navigation wrapper.

---
*PR created automatically by Jules for task [14501945173153804977](https://jules.google.com/task/14501945173153804977) started by @daribock*