### PR TITLE
🎨 Palette: Add accessibility attributes to mobile menu toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-04 - Added accessibility attributes to toggle menus
+**Learning:** Adding `aria-expanded` and `aria-controls` to standard toggle menus is a critical accessibility pattern for the Next.js header component in this app.
+**Action:** Always ensure toggleable menus communicate their current state and associated content container to screen readers.

--- a/components/layout/nav/header.tsx
+++ b/components/layout/nav/header.tsx
@@ -66,6 +66,8 @@ export const Header = () => {
             {/* Mobile menu button */}
             <button
               onClick={() => setMenuState(!menuState)}
+              aria-expanded={menuState}
+              aria-controls="mobile-menu"
               aria-label={menuState ? 'Close Menu' : 'Open Menu'}
               className="relative z-20 -m-2.5 -mr-4 block cursor-pointer p-2.5 lg:hidden h-12 w-12 flex items-center justify-center"
             >
@@ -75,6 +77,7 @@ export const Header = () => {
 
             {/* Mobile navigation menu */}
             <div
+              id="mobile-menu"
               className={cn(
                 'bg-background z-20 in-data-[state=active]:block lg:in-data-[state=active]:flex mb-6 hidden w-full flex-wrap items-center justify-end space-y-8 rounded-xl border p-6 shadow-2xl shadow-zinc-300/20 md:flex-nowrap lg:m-0 lg:hidden lg:w-fit lg:gap-6 lg:space-y-0 lg:border-transparent lg:bg-transparent lg:p-0 lg:shadow-none dark:shadow-none dark:lg:bg-transparent absolute top-16 left-0 right-0',
               )}


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-controls` to the mobile menu toggle button, and added the corresponding `id="mobile-menu"` to the menu container in `components/layout/nav/header.tsx`.
🎯 Why: To improve screen reader accessibility by correctly communicating the toggle state and structural relationship of the mobile navigation menu.
♿ Accessibility: Ensures that screen reader users are aware of when the mobile menu is open or closed and allows their assistive technologies to programmatically find the expanded menu.

---
*PR created automatically by Jules for task [1388668466474587470](https://jules.google.com/task/1388668466474587470) started by @daribock*