### PR TITLE
🎨 Palette: Add ARIA labels and focus states to footer social icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Accessible Dynamic CMS Icons
+**Learning:** Dynamic CMS icons (like those from TinaCMS) rendered as interactive elements (e.g., social links in the footer) often lack text content, making them inaccessible to screen readers.
+**Action:** Always programmatically map the `icon.name` property (or provide a sensible fallback) to an `aria-label` attribute on the wrapping interactive element (e.g., `<Link aria-label={icon.name}>`). Additionally, ensure proper keyboard accessibility by adding focus styles like `focus-visible:ring-2`.

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -160,7 +160,8 @@ export const Footer = async ({
                   href={link!.url!}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-gray-400 hover:text-white transition-colors"
+                  className="text-gray-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 rounded-sm"
+                  aria-label={link?.icon?.name || 'Social Media'}
                 >
                   <Icon
                     data={{ ...link!.icon, size: 'small' }}


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `focus-visible` styles to the social links in the footer. Also documented the learning in `.jules/palette.md`.
🎯 **Why**: The social links in the footer only display an icon and no text. Adding an `aria-label` ensures that screen readers can properly identify the links. Adding `focus-visible` styles ensures that the links are easily visible when navigating using the keyboard.
♿ **Accessibility**: Added `aria-label` and `focus-visible` styles for better screen reader and keyboard accessibility.

---
*PR created automatically by Jules for task [10255750988983478763](https://jules.google.com/task/10255750988983478763) started by @daribock*