### PR TITLE
⚡ Bolt: Optimize TinaCMS `pageConnection` queries to fix N+1 fetching bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-01 - [Iframe Lazy Loading]
 **Learning:** Missing comments for performance optimization was flagged during Code Review.
 **Action:** Always ensure to explicitly add a comment like `// ⚡ Bolt: ...` around the optimization logic to fulfill the rule requirement.
+
+## 2024-05-18 - [TinaCMS N+1 Query Optimization]
+**Learning:** By default, TinaCMS `pageConnection` fetches a small batch of pages. When iterating over all pages (like in `sitemap.ts` and static param generation), this leads to sequential N+1 network queries.
+**Action:** Always provide a `first` parameter with a larger reasonable batch size (e.g., `100`) to `pageConnection` to minimize round trips during build and runtime operations involving all items in a collection.

--- a/app/[locale]/[...urlSegments]/page.tsx
+++ b/app/[locale]/[...urlSegments]/page.tsx
@@ -119,7 +119,8 @@ export default async function Page({
 }
 
 export async function generateStaticParams() {
-  let pages = await client.queries.pageConnection();
+  // ⚡ Bolt: Increase batch size to 100 to reduce sequential N+1 queries during static param generation
+  let pages = await client.queries.pageConnection({ first: 100 });
   const allPages = pages;
 
   if (!allPages.data.pageConnection.edges) {
@@ -127,7 +128,9 @@ export async function generateStaticParams() {
   }
 
   while (pages.data.pageConnection.pageInfo.hasNextPage) {
+    // ⚡ Bolt: Increase batch size to 100 to reduce sequential N+1 queries during static param generation
     pages = await client.queries.pageConnection({
+      first: 100,
       after: pages.data.pageConnection.pageInfo.endCursor,
     });
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -23,11 +23,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Add all content pages
   try {
-    let pages = await client.queries.pageConnection();
+    // ⚡ Bolt: Increase batch size to 100 to reduce sequential N+1 queries during sitemap generation
+    let pages = await client.queries.pageConnection({ first: 100 });
     const pageEdges = [...(pages.data.pageConnection.edges ?? [])];
 
     while (pages.data.pageConnection.pageInfo.hasNextPage) {
+      // ⚡ Bolt: Increase batch size to 100 to reduce sequential N+1 queries during sitemap generation
       pages = await client.queries.pageConnection({
+        first: 100,
         after: pages.data.pageConnection.pageInfo.endCursor,
       });
       if (!pages.data.pageConnection.edges) break;


### PR DESCRIPTION
💡 What: Added `{ first: 100 }` argument to `client.queries.pageConnection` in `app/sitemap.ts` and `app/[locale]/[...urlSegments]/page.tsx`.
🎯 Why: The previous default query behavior fetched pages in very small batches, leading to N+1 sequential network requests when looping through all collection edges. This was a critical bottleneck during static page builds and sitemap generation.
📊 Impact: Reduces sequential N+1 round trips by up to ~90% (assuming 10 items/batch previously) during build steps involving full content scans.
🔬 Measurement: Verify by executing build commands or measuring iteration timings; observe reduced round trips in Next.js/TinaCMS query logs.

---
*PR created automatically by Jules for task [13501525461699296185](https://jules.google.com/task/13501525461699296185) started by @daribock*