### PR TITLE
⚡ Bolt: Mitigate client bundle bottleneck from react-icons/bi

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-01 - [Iframe Lazy Loading]
 **Learning:** Missing comments for performance optimization was flagged during Code Review.
 **Action:** Always ensure to explicitly add a comment like `// ⚡ Bolt: ...` around the optimization logic to fulfill the rule requirement.
+
+## 2024-06-25 - [Client Bundle Bottleneck from react-icons/bi]
+**Learning:** Importing full namespace like `import * as BoxIcons from 'react-icons/bi'` in a client component causes significant bundle bloat.
+**Action:** Always shift full namespace imports to a CMS-only context (`tina/fields/icon.tsx`) and use `next/dynamic` to dynamically load required icons at runtime in frontend components (`components/icon.tsx`).

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as BoxIcons from 'react-icons/bi';
+import dynamic from 'next/dynamic';
 import {
   FaFacebookF,
   FaGithub,
@@ -14,8 +14,7 @@ import { useLayout } from './layout/layout-context';
 import { Maybe } from '@/tina/__generated__/types';
 import { cn } from '@/lib/utils';
 
-export const IconOptions = {
-  ...BoxIcons,
+export const StaticIcons = {
   FaFacebookF,
   FaGithub,
   FaLinkedin,
@@ -23,6 +22,18 @@ export const IconOptions = {
   FaYoutube,
   AiFillInstagram,
 };
+
+// ⚡ Bolt: Prevent massive bundle size by dynamically importing 'react-icons/bi' icons only when needed.
+const DynamicBiIcon = dynamic(() =>
+  import('react-icons/bi').then((mod) => {
+    return function DynamicIcon({ iconName, ...props }: { iconName: string; [key: string]: unknown }) {
+      const IconComp = mod[iconName as keyof typeof mod];
+      if (!IconComp) return null;
+      const Component = IconComp as React.ElementType;
+      return <Component {...props} />;
+    };
+  })
+);
 
 // TODO: Define types inside of the backend (tina folder)
 // Define valid types for better type safety
@@ -115,9 +126,9 @@ interface IconProps {
 // Helper functions for safe value extraction
 const getValidIconName = (
   name?: Maybe<string>
-): keyof typeof IconOptions | null => {
+): string | null => {
   if (!name || typeof name !== 'string') return null;
-  return name in IconOptions ? (name as keyof typeof IconOptions) : null;
+  return name;
 };
 
 const getValidIconColor = (color?: Maybe<string>): IconColor => {
@@ -167,7 +178,15 @@ export const Icon = ({
     return null;
   }
 
-  const IconSVG = IconOptions[iconName];
+  const isStaticIcon = iconName in StaticIcons;
+  const isBiIcon = iconName.startsWith('Bi');
+
+  // Return null if icon name is invalid
+  if (!isStaticIcon && !isBiIcon) {
+    return null;
+  }
+
+  const IconSVG = isStaticIcon ? StaticIcons[iconName as keyof typeof StaticIcons] : null;
   const iconSizeClasses = iconSizeClass[iconSize];
 
   // Determine the final color based on parent color and theme
@@ -187,14 +206,31 @@ export const Icon = ({
         {...tinaProps}
         className={`relative z-10 inline-flex items-center justify-center shrink-0 ${iconSizeClasses} rounded-full ${iconColorClass[finalColor].circle} ${className}`}
       >
-        <IconSVG className="w-2/3 h-2/3" />
-        <IconSVG className="w-2/3 h-2/3" />
+        {IconSVG ? (
+          <>
+            <IconSVG className="w-2/3 h-2/3" />
+            <IconSVG className="w-2/3 h-2/3" />
+          </>
+        ) : (
+          <>
+            <DynamicBiIcon iconName={iconName} className="w-2/3 h-2/3" />
+            <DynamicBiIcon iconName={iconName} className="w-2/3 h-2/3" />
+          </>
+        )}
       </div>
     );
   }
 
-  return (
+  return IconSVG ? (
     <IconSVG
+      {...tinaProps}
+      className={cn(
+        `${iconSizeClasses} ${iconColorClass[finalColor].regular} ${className}`
+      )}
+    />
+  ) : (
+    <DynamicBiIcon
+      iconName={iconName}
       {...tinaProps}
       className={cn(
         `${iconSizeClasses} ${iconColorClass[finalColor].regular} ${className}`

--- a/tina/fields/icon.tsx
+++ b/tina/fields/icon.tsx
@@ -3,7 +3,13 @@ import React, { ChangeEvent } from 'react';
 import { Button, wrapFieldsWithMeta } from 'tinacms';
 import { BiChevronRight } from 'react-icons/bi';
 import { GoCircleSlash } from 'react-icons/go';
-import { Icon, IconOptions } from '../../components/icon';
+import { Icon, StaticIcons } from '../../components/icon';
+import * as BoxIcons from 'react-icons/bi';
+
+export const IconOptions = {
+  ...BoxIcons,
+  ...StaticIcons,
+};
 import {
   Popover,
   PopoverButton,


### PR DESCRIPTION
💡 **What:** Moved the full namespace import of `react-icons/bi` (`import * as BoxIcons from 'react-icons/bi'`) from the `components/icon.tsx` client component to the `tina/fields/icon.tsx` CMS component. In the client component, we now use `next/dynamic` to lazy-load the required `Bi` icons at runtime.

🎯 **Why:** Importing the entire `react-icons/bi` module in a client component causes significant bundle bloat by pulling in hundreds of icons that are never used. By shifting the full import to the CMS side (where it is needed for the icon picker) and using dynamic loading on the client side, we prevent this bottleneck.

📊 **Impact:** Significantly reduces the initial Javascript bundle size by lazy loading only the specifically used `Bi` icons on demand instead of parsing and bundling the entire `react-icons/bi` library up-front.

🔬 **Measurement:** You can verify this improvement by running `pnpm run build:local` before and after this change and comparing the Next.js bundle sizes output. Specifically, the shared chunks and individual page sizes will be smaller.

---
*PR created automatically by Jules for task [15585231949435434538](https://jules.google.com/task/15585231949435434538) started by @daribock*