### PR TITLE
🎨 Palette: Add ARIA labels to social links in footer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-25 - [Accessible Dynamic CMS Icons]
+**Learning:** When rendering interactive elements that wrap dynamic icons from a CMS (like social media links), the elements often lack descriptive text for screen readers because the visual content is purely icon-based.
+**Action:** Always map the dynamic icon name property (e.g., `icon.name`) to an `aria-label` on the wrapping element (e.g., `aria-label={link?.icon?.name || 'Social Media'}`) to ensure proper screen reader accessibility.

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -161,6 +161,7 @@ export const Footer = async ({
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-gray-400 hover:text-white transition-colors"
+                  aria-label={link?.icon?.name || 'Social Media'}
                 >
                   <Icon
                     data={{ ...link!.icon, size: 'small' }}


### PR DESCRIPTION
💡 What: Added aria-label to the Link component wrapping social icons in the footer.
🎯 Why: Social media icons generated from the CMS are visual-only. Screen readers lacked context for these interactive elements.
♿ Accessibility: The aria-label is dynamically populated based on the icon name or a fallback of 'Social Media', improving context for screen reader users.

---
*PR created automatically by Jules for task [12224967397472107828](https://jules.google.com/task/12224967397472107828) started by @daribock*