### PR TITLE
🎨 Palette: Improve accessibility of icon-only social links in footer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility for Icon-Only TinaCMS Links
+**Learning:** When rendering TinaCMS dynamic icons as interactive elements (e.g., social links in the footer), it's critical for screen reader accessibility to map the `icon.name` property to an `aria-label` on the wrapping interactive element (like `<Link>` or `<button>`). Otherwise, the elements appear empty to assistive technologies.
+**Action:** Always add `aria-label={link?.icon?.name || 'Fallback Text'}` or a visually hidden span containing descriptive text when rendering icon-only buttons or links.

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -161,6 +161,7 @@ export const Footer = async ({
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-gray-400 hover:text-white transition-colors"
+                  aria-label={link?.icon?.name || 'Social Media'}
                 >
                   <Icon
                     data={{ ...link!.icon, size: 'small' }}


### PR DESCRIPTION
💡 What: Added dynamic `aria-label`s to icon-only social media links in the `Footer` component (`components/layout/nav/footer.tsx`) and documented this A11y learning in `.jules/palette.md`.
🎯 Why: To ensure screen readers can announce the purpose of these interactive links since they lack visible text.
📸 Before/After: Before, screen readers would read nothing useful. After, they announce the social media platform's name (e.g., 'Instagram', 'YouTube') or 'Social Media' as a fallback.
♿ Accessibility: Improved screen reader navigation and context for interactive elements.

---
*PR created automatically by Jules for task [2080981171235039300](https://jules.google.com/task/2080981171235039300) started by @daribock*