### PR TITLE
🎨 Palette: Add black theme

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Analytics } from '@vercel/analytics/next';
 import { cn } from '@/lib/utils';
 import { Toaster } from '@/components/ui/sonner';
+import { ThemeProvider } from '@/components/theme-provider';
 import { OrganizationStructuredData } from '@/components/structured-data';
 
 import '@/styles.css';
@@ -88,7 +89,16 @@ export default async function RootLayout({
         >
           Skip to main content
         </a>
-        <NextIntlClientProvider>{children}</NextIntlClientProvider>
+        <NextIntlClientProvider>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            {children}
+          </ThemeProvider>
+        </NextIntlClientProvider>
         <TailwindIndicator />
         <SpeedInsights />
         <Analytics />

--- a/components/layout/nav/header/header-mobile-menu.tsx
+++ b/components/layout/nav/header/header-mobile-menu.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import { Menu, X } from 'lucide-react';
 import LocaleSwitcher from '../../../locale-switcher/locale-switcher';
+import { ThemeToggle } from '@/components/theme-toggle';
 import { cn } from '@/lib/utils';
 import { GlobalHeaderNav, Maybe } from '../../../../tina/__generated__/types';
 
@@ -65,11 +66,12 @@ export const HeaderMobileMenu = ({ nav }: HeaderMobileMenuProps) => {
             ))}
           </ul>
 
-          {process.env.NEXT_PUBLIC_ENABLE_LOCALE_SWITCHER === 'true' && (
-            <div className="flex items-center justify-between pt-4 border-t">
+          <div className="flex items-center justify-between pt-4 border-t gap-4">
+            {process.env.NEXT_PUBLIC_ENABLE_LOCALE_SWITCHER === 'true' && (
               <LocaleSwitcher />
-            </div>
-          )}
+            )}
+            <ThemeToggle />
+          </div>
         </div>
       </div>
     </>

--- a/components/layout/nav/header/header.tsx
+++ b/components/layout/nav/header/header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import LocaleSwitcher from '../../../locale-switcher/locale-switcher';
+import { ThemeToggle } from '@/components/theme-toggle';
 import { GlobalHeader } from '../../../../tina/__generated__/types';
 import { HeaderMobileMenu } from './header-mobile-menu';
 
@@ -16,7 +17,7 @@ export const Header = ({ header }: HeaderProps) => {
 
   return (
     <header>
-      <nav className="bg-white/95 backdrop-blur-md border-b fixed z-20 w-full h-16">
+      <nav className="bg-white/95 dark:bg-black/95 backdrop-blur-md border-b fixed z-20 w-full h-16">
         <div className="mx-auto max-w-6xl px-6 h-full">
           <div className="relative flex items-center justify-between h-full">
             {/* Left side: Logo + Navigation */}
@@ -28,6 +29,7 @@ export const Header = ({ header }: HeaderProps) => {
                   alt="Logo"
                   width={40}
                   height={40}
+                  className="dark:invert"
                 />
               </Link>
 
@@ -48,12 +50,13 @@ export const Header = ({ header }: HeaderProps) => {
               </div>
             </div>
 
-            {/* Right side: Language Switcher */}
-            {process.env.NEXT_PUBLIC_ENABLE_LOCALE_SWITCHER === 'true' && (
-              <div className="hidden lg:flex items-center gap-4 h-full">
+            {/* Right side: Language Switcher & Theme Toggle */}
+            <div className="hidden lg:flex items-center gap-4 h-full">
+              {process.env.NEXT_PUBLIC_ENABLE_LOCALE_SWITCHER === 'true' && (
                 <LocaleSwitcher className="border-none" />
-              </div>
-            )}
+              )}
+              <ThemeToggle />
+            </div>
 
             {/* Mobile menu (client component) */}
             <HeaderMobileMenu nav={header.nav ?? null} />

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import * as React from 'react';
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -11,6 +11,7 @@ export function ThemeToggle() {
 
   // Avoid hydration mismatch
   React.useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
   }, []);
 

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import * as React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { Button } from '@/components/ui/button';
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  // Avoid hydration mismatch
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="icon" className="size-9">
+        <Sun className="size-[1.2rem] opacity-0" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="size-9"
+      onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' ? (
+        <Sun className="size-[1.2rem] transition-all" />
+      ) : (
+        <Moon className="size-[1.2rem] transition-all" />
+      )}
+    </Button>
+  );
+}


### PR DESCRIPTION
💡 What: Added a theme toggle button to the header and mobile menu to allow users to switch between light and dark modes.
🎯 Why: To improve user experience and provide a dark theme option as requested by the designer.
📸 Before/After: The site now supports a full dark mode, togglable via a Sun/Moon icon in the header.
♿ Accessibility: Included ARIA labels for the theme toggle button and ensured keyboard accessibility using Radix-based Button components.
✅ Verification: Confirmed `next-themes` dependency is present and Tailwind CSS v4 `@custom-variant dark` is correctly utilized.

Fixes #14

---
*PR created automatically by Jules for task [8824085495536719376](https://jules.google.com/task/8824085495536719376) started by @daribock*