### PR TITLE
⚡ Bolt: [Performance improvement] Lazy load icons to reduce bundle bloat

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-01 - [Iframe Lazy Loading]
 **Learning:** Missing comments for performance optimization was flagged during Code Review.
 **Action:** Always ensure to explicitly add a comment like `// ⚡ Bolt: ...` around the optimization logic to fulfill the rule requirement.
+
+## 2026-06-08 - [Bundle Bloat with React Icons]
+**Learning:** Importing full namespaces like `import * as BoxIcons from 'react-icons/bi'` in client components forces the bundler to include the entire set (e.g. 1.5k+ icons) into the initial javascript bundle, creating massive bundle bloat.
+**Action:** When working with dynamic icon resolution, move full namespace imports to CMS-only files. For frontend rendering, use `next/dynamic` wrappers resolving by icon prefix (e.g., Bi, Fa, Ai) to lazily load chunks only when rendered.

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -1,28 +1,10 @@
 'use client';
 
-import * as BoxIcons from 'react-icons/bi';
-import {
-  FaFacebookF,
-  FaGithub,
-  FaLinkedin,
-  FaXTwitter,
-  FaYoutube,
-} from 'react-icons/fa6';
-import { AiFillInstagram } from 'react-icons/ai';
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { useLayout } from './layout/layout-context';
 import { Maybe } from '@/tina/__generated__/types';
 import { cn } from '@/lib/utils';
-
-export const IconOptions = {
-  ...BoxIcons,
-  FaFacebookF,
-  FaGithub,
-  FaLinkedin,
-  FaXTwitter,
-  FaYoutube,
-  AiFillInstagram,
-};
 
 // TODO: Define types inside of the backend (tina folder)
 // Define valid types for better type safety
@@ -81,12 +63,54 @@ interface IconProps {
   ariaLabel?: string;
 }
 
+// ⚡ Bolt: Lazy loading icon sets to prevent massive bundle bloat.
+// Full namespaces are moved to tina/fields/icon.tsx (CMS only).
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const dynamicIconLoaders: Record<string, React.ComponentType<any>> = {
+  Bi: dynamic(() =>
+    import('react-icons/bi').then((mod) => {
+      const BiIconLoader = (props: any) => {
+        const Component = (mod as any)[props.name] as React.ElementType;
+        return Component ? <Component {...props} /> : null;
+      };
+      BiIconLoader.displayName = 'BiIconLoader';
+      return BiIconLoader;
+    })
+  ),
+  Fa: dynamic(() =>
+    import('react-icons/fa6').then((mod) => {
+      const FaIconLoader = (props: any) => {
+        const Component = (mod as any)[props.name] as React.ElementType;
+        return Component ? <Component {...props} /> : null;
+      };
+      FaIconLoader.displayName = 'FaIconLoader';
+      return FaIconLoader;
+    })
+  ),
+  Ai: dynamic(() =>
+    import('react-icons/ai').then((mod) => {
+      const AiIconLoader = (props: any) => {
+        const Component = (mod as any)[props.name] as React.ElementType;
+        return Component ? <Component {...props} /> : null;
+      };
+      AiIconLoader.displayName = 'AiIconLoader';
+      return AiIconLoader;
+    })
+  ),
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const getIconPrefix = (name: string): string | null => {
+  if (name.startsWith('Bi')) return 'Bi';
+  if (name.startsWith('Fa')) return 'Fa';
+  if (name.startsWith('Ai')) return 'Ai';
+  return null;
+};
+
 // Helper functions for safe value extraction
-const getValidIconName = (
-  name?: Maybe<string>
-): keyof typeof IconOptions | null => {
+const getValidIconName = (name?: Maybe<string>): string | null => {
   if (!name || typeof name !== 'string') return null;
-  return name in IconOptions ? (name as keyof typeof IconOptions) : null;
+  return name;
 };
 
 const getValidIconColor = (color?: Maybe<string>): IconColor => {
@@ -132,7 +156,13 @@ export const Icon = ({
     return null;
   }
 
-  const IconSVG = IconOptions[iconName];
+  const iconPrefix = getIconPrefix(iconName);
+  const IconSVG = iconPrefix ? dynamicIconLoaders[iconPrefix] : null;
+
+  if (!IconSVG) {
+    return null;
+  }
+
   const iconSizeClasses = iconSizeClass[iconSize];
   const resolvedDecorative =
     decorative ?? (typeof data.decorative === 'boolean' ? data.decorative : true);
@@ -155,6 +185,7 @@ export const Icon = ({
 
   return (
     <IconSVG
+      name={iconName}
       {...tinaProps}
       {...a11yProps}
       className={cn(

--- a/tina/fields/icon.tsx
+++ b/tina/fields/icon.tsx
@@ -3,7 +3,17 @@ import React, { ChangeEvent } from 'react';
 import { Button, wrapFieldsWithMeta } from 'tinacms';
 import { BiChevronRight } from 'react-icons/bi';
 import { GoCircleSlash } from 'react-icons/go';
-import { Icon, IconOptions } from '../../components/icon';
+import { Icon } from '../../components/icon';
+import * as BoxIcons from 'react-icons/bi';
+import {
+  FaFacebookF,
+  FaGithub,
+  FaLinkedin,
+  FaXTwitter,
+  FaYoutube,
+} from 'react-icons/fa6';
+import { AiFillInstagram } from 'react-icons/ai';
+
 import {
   Popover,
   PopoverButton,
@@ -11,6 +21,16 @@ import {
   PopoverPanel,
 } from '@headlessui/react';
 import { ColorPickerInput } from './color';
+
+export const IconOptions = {
+  ...BoxIcons,
+  FaFacebookF,
+  FaGithub,
+  FaLinkedin,
+  FaXTwitter,
+  FaYoutube,
+  AiFillInstagram,
+};
 
 const parseIconName = (name: string) => {
   const splitName = name.split(/(?=[A-Z])/);


### PR DESCRIPTION
💡 What: Refactored `components/icon.tsx` to stop statically importing full namespaces from `react-icons` (e.g. `import * as BoxIcons from 'react-icons/bi'`). Moved static namespace definitions to `tina/fields/icon.tsx` for CMS use only. Added a lazy loading implementation using `next/dynamic` based on icon prefixes.
🎯 Why: Importing full namespaces forces Webpack/Turbopack to bundle all ~1,500+ icons per set into the initial javascript payload. By lazily resolving the icons when rendering, we significantly reduce bundle bloat and speed up Time-to-Interactive (TTI). 
📊 Impact: Expected massive reduction in initial main JS bundle size as icons are only fetched asynchronously in separate chunks on demand.
🔬 Measurement: Verify with `pnpm run build` or `npm run analyze` that `react-icons/*` no longer dominate the initial route bundles. Run `pnpm lint` and `pnpm run lint:tsc` to ensure typing and linting pass.

---
*PR created automatically by Jules for task [15647526530788347289](https://jules.google.com/task/15647526530788347289) started by @daribock*