### PR TITLE
Update Address Formatting in Location Section

### DIFF
--- a/components/blocks/location-section.tsx
+++ b/components/blocks/location-section.tsx
@@ -42,8 +42,8 @@ export const LocationSection = ({ data }: { data: PageBlocksLocation }) => {
                       {contact.street} {contact.number}
                       <br />
                       {contact.ort}
-                      {/* TODO: Should we add this? <br />
-                      Deutschland */}
+                      <br />
+                      Deutschland
                     </Link>
                   </div>
                 </Typography>


### PR DESCRIPTION
Update Address Formatting in Location Section

Uncommented the display of 'Deutschland' in the address element
found in components/blocks/location-section.tsx to be consistently visible
with the rest of the street, number, and orth fields.

---
*PR created automatically by Jules for task [16179189716367152256](https://jules.google.com/task/16179189716367152256) started by @daribock*