### PR TITLE
⚡ Bolt: Optimize TinaCMS sequential query fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-01 - [Iframe Lazy Loading]
 **Learning:** Missing comments for performance optimization was flagged during Code Review.
 **Action:** Always ensure to explicitly add a comment like `// ⚡ Bolt: ...` around the optimization logic to fulfill the rule requirement.
+
+## 2024-05-15 - [TinaCMS Batch Fetching]
+**Learning:** Default TinaCMS `pageConnection` requests can cause severe N+1 sequential fetching delays (N+1 query problem).
+**Action:** When querying connection nodes sequentially via `hasNextPage` and `endCursor`, always use `first: 100` to significantly increase the batch size and reduce roundtrips.

--- a/app/[locale]/[...urlSegments]/page.tsx
+++ b/app/[locale]/[...urlSegments]/page.tsx
@@ -119,7 +119,8 @@ export default async function Page({
 }
 
 export async function generateStaticParams() {
-  let pages = await client.queries.pageConnection();
+  // ⚡ Bolt: Increase batch size with `first: 100` to speed up build time fetching.
+  let pages = await client.queries.pageConnection({ first: 100 });
   const allPages = pages;
 
   if (!allPages.data.pageConnection.edges) {
@@ -127,7 +128,9 @@ export async function generateStaticParams() {
   }
 
   while (pages.data.pageConnection.pageInfo.hasNextPage) {
+    // ⚡ Bolt: Fetch more results per batch to minimize sequential query round-trips.
     pages = await client.queries.pageConnection({
+      first: 100,
       after: pages.data.pageConnection.pageInfo.endCursor,
     });
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -23,11 +23,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Add all content pages
   try {
-    let pages = await client.queries.pageConnection();
+    // ⚡ Bolt: Use `first: 100` to optimize TinaCMS sequential fetching and reduce N+1 queries.
+    let pages = await client.queries.pageConnection({ first: 100 });
     const pageEdges = [...(pages.data.pageConnection.edges ?? [])];
 
     while (pages.data.pageConnection.pageInfo.hasNextPage) {
+      // ⚡ Bolt: Increase batch size with `first: 100` for faster sequential fetching.
       pages = await client.queries.pageConnection({
+        first: 100,
         after: pages.data.pageConnection.pageInfo.endCursor,
       });
       if (!pages.data.pageConnection.edges) break;


### PR DESCRIPTION
💡 What: Increased the `first` argument batch size to 100 on `pageConnection` queries within sequential fetching loops.
🎯 Why: To solve an N+1 query problem during static param extraction and sitemap generation where default limits (like 10) require too many sequential HTTP requests.
📊 Impact: Expected to significantly reduce total network roundtrips during Next.js static builds or sitemap regeneration processes, leading to faster execution times.
🔬 Measurement: Verify by executing a full Next build or observing reduced logging outputs from TinaCMS requests during local development when generating `[...urlSegments]` routes.

---
*PR created automatically by Jules for task [16340302916702388297](https://jules.google.com/task/16340302916702388297) started by @daribock*