### PR TITLE
🎨 Palette: [Focus state accessibility for Links]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2025-06-08 - Consistent Keyboard Focus Indicators for Next.js Links
-**Learning:** Next.js `<Link>` components wrapped around text or icons (e.g., in Navigation/Headers/Footers) often lack visible focus outlines in Tailwind environments, leading to poor keyboard accessibility where users cannot tell which item is focused. Even when `text-muted-foreground` and `hover:text-accent-foreground` are used, keyboard focus doesn't typically trigger a visible change unless explicitly styled.
-**Action:** When adding or auditing links across custom Next.js components, always explicitly include `focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm` (or similar focus tokens) to ensure a visible, accessible ring around the interactive element when navigated via keyboard.
+## 2025-02-28 - Focus States for Next.js Links
+**Learning:** Next.js `<Link>` components, especially those wrapping images (like logos) or text with utility classes for font colors, often lack default focus rings for keyboard navigation.
+**Action:** Explicitly add `focus-visible` Tailwind classes (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm`) to custom Next.js `<Link>` components. For links wrapping images, ensure they have `inline-block` so the focus ring correctly wraps the image.

--- a/components/blocks/location-section.tsx
+++ b/components/blocks/location-section.tsx
@@ -38,6 +38,7 @@ export const LocationSection = ({ data }: { data: PageBlocksLocation }) => {
                       target="_blank"
                       rel="noopener noreferrer"
                       aria-label={`${contactT('Address')} (opens in a new tab)`}
+                      className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm"
                     >
                       {contact.street} {contact.number}
                       <br />
@@ -57,7 +58,7 @@ export const LocationSection = ({ data }: { data: PageBlocksLocation }) => {
 
                   <Link
                     href={`tel:${contact.phone}`}
-                    className=" transition-colors"
+                    className="transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm"
                   >
                     {contact.phone}
                   </Link>
@@ -71,7 +72,7 @@ export const LocationSection = ({ data }: { data: PageBlocksLocation }) => {
                   <h3 className="m-0!">{contactT('Email')}</h3>
                   <Link
                     href={`mailto:${contact.email}`}
-                    className=" transition-colors"
+                    className="transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm"
                   >
                     {contact.email}
                   </Link>

--- a/components/layout/nav/header/header.tsx
+++ b/components/layout/nav/header/header.tsx
@@ -22,7 +22,10 @@ export const Header = ({ header }: HeaderProps) => {
             {/* Left side: Logo + Navigation */}
             <div className="flex items-center gap-8 h-full">
               {/* Logo */}
-              <Link href="/">
+              <Link
+                href="/"
+                className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm inline-block"
+              >
                 <Image
                   src="/uploads/logos/betania-logo-transparent-schwarz.svg"
                   alt="Logo"


### PR DESCRIPTION
💡 What: Added focus-visible styling to `<Link>` components in the location section and header logo to enhance keyboard navigation.
🎯 Why: The original links and logos lacked visual focus rings when navigating purely by keyboard, violating accessibility best practices.
📸 Before/After: (Not a major visual change for mouse users, purely focus-state enhancement)
♿ Accessibility: Ensures that keyboard users and users relying on assistive tech can see exactly which item is currently focused via a prominent focus ring (`focus-visible:ring-2 focus-visible:ring-ring`).

---
*PR created automatically by Jules for task [7542579838935268177](https://jules.google.com/task/7542579838935268177) started by @daribock*