### PR TITLE
🎨 Palette: Focus state accessibility for mobile menu

### DIFF
--- a/components/layout/nav/header/header-mobile-menu.tsx
+++ b/components/layout/nav/header/header-mobile-menu.tsx
@@ -22,7 +22,7 @@ export const HeaderMobileMenu = ({ nav }: HeaderMobileMenuProps) => {
         aria-label={isOpen ? 'Close Menu' : 'Open Menu'}
         aria-expanded={isOpen}
         aria-controls="mobile-nav-menu"
-        className="relative z-20 -m-2.5 -mr-4 cursor-pointer p-2.5 lg:hidden h-12 w-12 flex items-center justify-center"
+        className="relative z-20 -m-2.5 -mr-4 cursor-pointer p-2.5 lg:hidden h-12 w-12 flex items-center justify-center focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm"
       >
         <Menu
           className={cn(


### PR DESCRIPTION
💡 **What:** Added `focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm` classes to the mobile hamburger menu `<button>`. Added a new entry to `.jules/palette.md` to log this learning.\n🎯 **Why:** To improve keyboard accessibility. Custom interactive elements like the mobile menu button do not have default browser focus rings when styled with Tailwind. This makes it impossible for keyboard-only users to know when they are focused on the menu toggle.\n📸 **Before/After:** The button now displays a distinct primary color ring when navigated to via the `Tab` key.\n♿ **Accessibility:** Solves a WCAG 2.4.7 Focus Visible issue for the main mobile navigation toggle.

---
*PR created automatically by Jules for task [9682709863738876946](https://jules.google.com/task/9682709863738876946) started by @daribock*