### PR TITLE
🎨 Palette: Add focus-visible states to mobile menu button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-28 - Focus States for Next.js Links
 **Learning:** Next.js `<Link>` components, especially those wrapping images (like logos) or text with utility classes for font colors, often lack default focus rings for keyboard navigation.
 **Action:** Explicitly add `focus-visible` Tailwind classes (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm`) to custom Next.js `<Link>` components. For links wrapping images, ensure they have `inline-block` so the focus ring correctly wraps the image.
+
+## 2026-07-06 - Focus States for Interactive Elements
+**Learning:** Custom interactive elements, like custom buttons used for mobile menus, can lack default focus rings for keyboard navigation. While ARIA labels are essential, visual feedback for focus state is just as crucial for keyboard users to understand where they are.
+**Action:** Always ensure custom interactive elements like custom buttons have explicit `focus-visible` Tailwind classes (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm`) applied.

--- a/components/layout/nav/header/header-mobile-menu.tsx
+++ b/components/layout/nav/header/header-mobile-menu.tsx
@@ -22,7 +22,7 @@ export const HeaderMobileMenu = ({ nav }: HeaderMobileMenuProps) => {
         aria-label={isOpen ? 'Close Menu' : 'Open Menu'}
         aria-expanded={isOpen}
         aria-controls="mobile-nav-menu"
-        className="relative z-20 -m-2.5 -mr-4 cursor-pointer p-2.5 lg:hidden h-12 w-12 flex items-center justify-center"
+        className="relative z-20 -m-2.5 -mr-4 cursor-pointer p-2.5 lg:hidden h-12 w-12 flex items-center justify-center focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm"
       >
         <Menu
           className={cn(


### PR DESCRIPTION
💡 What: Added `focus-visible` Tailwind classes to the mobile menu toggle button.
🎯 Why: To improve keyboard navigation accessibility by providing visual feedback when the button is focused.
📸 Before/After: The button now shows an outline when focused using the keyboard.
♿ Accessibility: Improves keyboard accessibility by ensuring the custom interactive element has a visible focus state.


---
*PR created automatically by Jules for task [9374779523427736606](https://jules.google.com/task/9374779523427736606) started by @daribock*