### PR TITLE
⚡ Bolt: fix N+1 queries in static generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-01 - [Iframe Lazy Loading]
 **Learning:** Missing comments for performance optimization was flagged during Code Review.
 **Action:** Always ensure to explicitly add a comment like `// ⚡ Bolt: ...` around the optimization logic to fulfill the rule requirement.
+
+## 2024-05-01 - [TinaCMS N+1 Query Fix]
+**Learning:** Sequential fetching using default small batch sizes for GraphQL connections in static generation (e.g. `client.queries.pageConnection()`) creates significant overhead in Next.js builds. Also, executing Tina commands or using PNPM may generate an untracked, large `pnpm-lock.yaml` which needs to be removed before PR creation.
+**Action:** Always specify a larger batch size (e.g., `first: 100`) when looping through `pageInfo.hasNextPage` in static generation scripts to batch operations. And always check `git status` to avoid committing unintended auto-generated package manager lockfiles.

--- a/app/[locale]/[...urlSegments]/page.tsx
+++ b/app/[locale]/[...urlSegments]/page.tsx
@@ -119,7 +119,8 @@ export default async function Page({
 }
 
 export async function generateStaticParams() {
-  let pages = await client.queries.pageConnection();
+  // ⚡ Bolt: Increase batch size to 100 to reduce sequential fetching overhead
+  let pages = await client.queries.pageConnection({ first: 100 });
   const allPages = pages;
 
   if (!allPages.data.pageConnection.edges) {
@@ -127,7 +128,9 @@ export async function generateStaticParams() {
   }
 
   while (pages.data.pageConnection.pageInfo.hasNextPage) {
+    // ⚡ Bolt: Increase batch size to 100 to reduce sequential fetching overhead
     pages = await client.queries.pageConnection({
+      first: 100,
       after: pages.data.pageConnection.pageInfo.endCursor,
     });
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -23,11 +23,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Add all content pages
   try {
-    let pages = await client.queries.pageConnection();
+    // ⚡ Bolt: Increase batch size to 100 to reduce sequential fetching overhead
+    let pages = await client.queries.pageConnection({ first: 100 });
     const pageEdges = [...(pages.data.pageConnection.edges ?? [])];
 
     while (pages.data.pageConnection.pageInfo.hasNextPage) {
+      // ⚡ Bolt: Increase batch size to 100 to reduce sequential fetching overhead
       pages = await client.queries.pageConnection({
+        first: 100,
         after: pages.data.pageConnection.pageInfo.endCursor,
       });
       if (!pages.data.pageConnection.edges) break;


### PR DESCRIPTION
💡 What: Increased the GraphQL connection batch size (`first: 100`) for the `pageConnection` query in both `app/sitemap.ts` and `app/[locale]/[...urlSegments]/page.tsx`'s static generation function.

🎯 Why: The default batch size forces the application to execute a high volume of sequential network calls (N+1 queries) during the static generation and sitemap building processes as it paginates through every content page.

📊 Impact: Reduces the number of network round-trips by significantly increasing the batch size, thereby accelerating the Next.js static build process and reducing the load on the Tina API server.

🔬 Measurement: Observe the build time for `pnpm build` (specifically the Next.js static generation phase), and review the reduced count of GraphQL query batches via tracing/logs.

---
*PR created automatically by Jules for task [14320220976766062909](https://jules.google.com/task/14320220976766062909) started by @daribock*