### PR TITLE
🎨 Palette: Improve Radix Select accessibility in LocaleSwitcher

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-28 - Focus States for Next.js Links
 **Learning:** Next.js `<Link>` components, especially those wrapping images (like logos) or text with utility classes for font colors, often lack default focus rings for keyboard navigation.
 **Action:** Explicitly add `focus-visible` Tailwind classes (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm`) to custom Next.js `<Link>` components. For links wrapping images, ensure they have `inline-block` so the focus ring correctly wraps the image.
+
+## 2025-03-02 - Radix UI Select Accessibility
+**Learning:** For Radix UI `Select` components, placing an accessible label in an adjacent `<span className="sr-only">` does not correctly associate the label with the interactive `<SelectTrigger>` button.
+**Action:** When a visual `<label>` is not present, add `aria-label` directly to the `<SelectTrigger>` component to ensure screen readers correctly announce the button's purpose.

--- a/components/locale-switcher/locale-switcher-select.tsx
+++ b/components/locale-switcher/locale-switcher-select.tsx
@@ -42,13 +42,13 @@ export default function LocaleSwitcherSelect({
 
   return (
     <div className="relative">
-      <span className="sr-only">{label}</span>
       <Select
         defaultValue={defaultValue}
         disabled={isPending}
         onValueChange={onValueChange}
       >
         <SelectTrigger
+          aria-label={label}
           className={cn(
             'w-fit text-sm text-muted-foreground shadow-none bg-transparent',
             className


### PR DESCRIPTION
💡 What: Moved the accessible label from a detached `.sr-only` span directly to the `<SelectTrigger>` as an `aria-label` in the `LocaleSwitcherSelect` component.
🎯 Why: To ensure screen readers properly announce the language selection dropdown when it receives focus, as the previous detached span was not programmatically associated with the button.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Ensures the interactive `<SelectTrigger>` element has a proper accessible name (e.g., "Change language") announced by assistive technologies.

✅ Verification: Confirmed that `bun test` and `pnpm lint` passed without errors.

---
*PR created automatically by Jules for task [16852447591811574787](https://jules.google.com/task/16852447591811574787) started by @daribock*