### PR TITLE
⚡ Bolt: Optimize TinaCMS sequential queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-01 - [Iframe Lazy Loading]
 **Learning:** Missing comments for performance optimization was flagged during Code Review.
 **Action:** Always ensure to explicitly add a comment like `// ⚡ Bolt: ...` around the optimization logic to fulfill the rule requirement.
+
+## 2024-05-03 - [TinaCMS N+1 Query Optimization]
+**Learning:** Sequential network requests in `pageConnection` can be drastically reduced by explicitly defining a large batch size parameter.
+**Action:** Ensure that paginated endpoints explicitly define a `first` parameter (e.g., `first: 100`) to pull data in fewer fetches.

--- a/app/[locale]/[...urlSegments]/page.tsx
+++ b/app/[locale]/[...urlSegments]/page.tsx
@@ -119,7 +119,8 @@ export default async function Page({
 }
 
 export async function generateStaticParams() {
-  let pages = await client.queries.pageConnection();
+  // ⚡ Bolt: Increase batch size to 100 to reduce sequential network requests
+  let pages = await client.queries.pageConnection({ first: 100 });
   const allPages = pages;
 
   if (!allPages.data.pageConnection.edges) {
@@ -127,7 +128,9 @@ export async function generateStaticParams() {
   }
 
   while (pages.data.pageConnection.pageInfo.hasNextPage) {
+    // ⚡ Bolt: Increase batch size to 100 to reduce sequential network requests
     pages = await client.queries.pageConnection({
+      first: 100,
       after: pages.data.pageConnection.pageInfo.endCursor,
     });
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -23,11 +23,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Add all content pages
   try {
-    let pages = await client.queries.pageConnection();
+    // ⚡ Bolt: Increase batch size to 100 to reduce sequential network requests
+    let pages = await client.queries.pageConnection({ first: 100 });
     const pageEdges = [...(pages.data.pageConnection.edges ?? [])];
 
     while (pages.data.pageConnection.pageInfo.hasNextPage) {
+      // ⚡ Bolt: Increase batch size to 100 to reduce sequential network requests
       pages = await client.queries.pageConnection({
+        first: 100,
         after: pages.data.pageConnection.pageInfo.endCursor,
       });
       if (!pages.data.pageConnection.edges) break;


### PR DESCRIPTION
💡 What: Added `first: 100` parameter to `client.queries.pageConnection` in `generateStaticParams` and sitemap logic.
🎯 Why: Without a specified batch size, GraphQL paginated endpoints default to smaller result sets. Setting `first: 100` significantly reduces the number of sequential network requests required to fetch all pages during the build process.
📊 Impact: Considerably faster static site and sitemap generation by minimizing network latency and sequential delays.
🔬 Measurement: Compare the time taken during the Next.js `generateStaticParams` phase and measure network requests made to TinaCloud.

---
*PR created automatically by Jules for task [17076140774040126245](https://jules.google.com/task/17076140774040126245) started by @daribock*