### PR TITLE
⚡ Bolt: optimize pageConnection batch size for faster static generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-01 - [Iframe Lazy Loading]
 **Learning:** Missing comments for performance optimization was flagged during Code Review.
 **Action:** Always ensure to explicitly add a comment like `// ⚡ Bolt: ...` around the optimization logic to fulfill the rule requirement.
+
+## 2024-05-08 - [GraphQL Pagination Optimization]
+**Learning:** `client.queries.pageConnection` in TinaCMS defaults to fetching a small number of items per request. During static site generation or sitemap building where all items are needed, this leads to inefficient N+1 sequential requests.
+**Action:** Always pass `{ first: 100 }` (or a larger reasonable batch size) when iterating through a full `pageConnection` loop to significantly reduce network roundtrips.

--- a/app/[locale]/[...urlSegments]/page.tsx
+++ b/app/[locale]/[...urlSegments]/page.tsx
@@ -119,7 +119,8 @@ export default async function Page({
 }
 
 export async function generateStaticParams() {
-  let pages = await client.queries.pageConnection();
+  // ⚡ Bolt: Increase batch size to reduce sequential network requests
+  let pages = await client.queries.pageConnection({ first: 100 });
   const allPages = pages;
 
   if (!allPages.data.pageConnection.edges) {
@@ -129,6 +130,8 @@ export async function generateStaticParams() {
   while (pages.data.pageConnection.pageInfo.hasNextPage) {
     pages = await client.queries.pageConnection({
       after: pages.data.pageConnection.pageInfo.endCursor,
+      // ⚡ Bolt: Increase batch size to reduce sequential network requests
+      first: 100,
     });
 
     if (!pages.data.pageConnection.edges) {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -23,12 +23,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Add all content pages
   try {
-    let pages = await client.queries.pageConnection();
+    // ⚡ Bolt: Increase batch size to reduce sequential network requests
+    let pages = await client.queries.pageConnection({ first: 100 });
     const pageEdges = [...(pages.data.pageConnection.edges ?? [])];
 
     while (pages.data.pageConnection.pageInfo.hasNextPage) {
       pages = await client.queries.pageConnection({
         after: pages.data.pageConnection.pageInfo.endCursor,
+        // ⚡ Bolt: Increase batch size to reduce sequential network requests
+        first: 100,
       });
       if (!pages.data.pageConnection.edges) break;
       pageEdges.push(...pages.data.pageConnection.edges);


### PR DESCRIPTION
💡 What: Added `{ first: 100 }` to `client.queries.pageConnection` calls in `app/sitemap.ts` and `app/[locale]/[...urlSegments]/page.tsx`.

🎯 Why: During sitemap generation and static parameters generation, the code iterates through all pages using GraphQL pagination. By default, it fetches a small number of items (often 10) per request. By increasing the batch size to 100, we significantly reduce the number of sequential network round-trips needed to fetch all pages, speeding up the build and sitemap generation process.

📊 Impact: Reduces the number of network requests by approximately 90% (assuming default page size of 10) during static page and sitemap generation when the site scales up.

🔬 Measurement: Observe the build time (`pnpm build`) and network logs when hitting the `/sitemap.xml` endpoint or generating static routes. The number of sequential GraphQL requests to TinaCMS for page nodes will be significantly lower.

---
*PR created automatically by Jules for task [13808910750842054044](https://jules.google.com/task/13808910750842054044) started by @daribock*