### PR TITLE
🎨 Palette: Improve screen reader accessibility for Locale Switcher

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-28 - Focus States for Next.js Links
 **Learning:** Next.js `<Link>` components, especially those wrapping images (like logos) or text with utility classes for font colors, often lack default focus rings for keyboard navigation.
 **Action:** Explicitly add `focus-visible` Tailwind classes (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm`) to custom Next.js `<Link>` components. For links wrapping images, ensure they have `inline-block` so the focus ring correctly wraps the image.
+
+## 2025-03-05 - ARIA Labels for Radix UI Select Components
+**Learning:** For Radix UI `Select` components without a visual `<label>`, using an adjacent visually hidden element (e.g., `<span className="sr-only">`) does not properly associate the label for screen readers.
+**Action:** Apply the `aria-label` attribute directly to the `<SelectTrigger>` component to ensure proper programmatic association for screen readers.

--- a/components/locale-switcher/locale-switcher-select.tsx
+++ b/components/locale-switcher/locale-switcher-select.tsx
@@ -42,13 +42,13 @@ export default function LocaleSwitcherSelect({
 
   return (
     <div className="relative">
-      <span className="sr-only">{label}</span>
       <Select
         defaultValue={defaultValue}
         disabled={isPending}
         onValueChange={onValueChange}
       >
         <SelectTrigger
+          aria-label={label}
           className={cn(
             'w-fit text-sm text-muted-foreground shadow-none bg-transparent',
             className


### PR DESCRIPTION
💡 **What:** Replaced an adjacent `sr-only` span with an `aria-label` directly on the `<SelectTrigger>` component inside `LocaleSwitcherSelect`.
🎯 **Why:** Radix UI's `Select` component doesn't correctly associate visually hidden sibling spans for screen readers. Using `aria-label` on the trigger directly improves screen reader accessibility.
📸 **Before/After:** Not applicable (visuals are unchanged, purely an accessibility improvement).
♿ **Accessibility:** Screen readers will now properly announce the label (e.g. "Language" or "Sprache") when the user focuses on the Locale Switcher trigger.

---
*PR created automatically by Jules for task [11018492991225152879](https://jules.google.com/task/11018492991225152879) started by @daribock*