### PR TITLE
🎨 Palette: Improve screen reader accessibility for Locale Switcher

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-28 - Focus States for Next.js Links
 **Learning:** Next.js `<Link>` components, especially those wrapping images (like logos) or text with utility classes for font colors, often lack default focus rings for keyboard navigation.
 **Action:** Explicitly add `focus-visible` Tailwind classes (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm`) to custom Next.js `<Link>` components. For links wrapping images, ensure they have `inline-block` so the focus ring correctly wraps the image.
+
+## 2025-02-28 - Radix UI Select Accessibility
+**Learning:** Radix UI `Select` components that do not have a visual label should use `aria-label` directly on the `<SelectTrigger>` rather than placing an adjacent visually hidden element (like `<span className="sr-only">`). Using a separate hidden element can lead to poor programmatic association for screen readers.
+**Action:** Apply the `aria-label` attribute directly to the `<SelectTrigger>` when omitting a visual `<label>` for Radix UI `Select` components.

--- a/components/locale-switcher/locale-switcher-select.tsx
+++ b/components/locale-switcher/locale-switcher-select.tsx
@@ -42,13 +42,13 @@ export default function LocaleSwitcherSelect({
 
   return (
     <div className="relative">
-      <span className="sr-only">{label}</span>
       <Select
         defaultValue={defaultValue}
         disabled={isPending}
         onValueChange={onValueChange}
       >
         <SelectTrigger
+          aria-label={label}
           className={cn(
             'w-fit text-sm text-muted-foreground shadow-none bg-transparent',
             className


### PR DESCRIPTION
💡 **What:** Replaced the adjacent `.sr-only` visually hidden span with a direct `aria-label` attribute on the `SelectTrigger` in `LocaleSwitcherSelect`. Also documented this Radix UI Select a11y pattern in `.jules/palette.md`.

🎯 **Why:** To improve screen reader accessibility. When a visual label is omitted from Radix UI components like `Select`, placing an adjacent hidden element for screen readers often breaks programmatic association, whereas providing an `aria-label` directly on the trigger element works robustly.

📸 **Before/After:** Not a visual change.

♿ **Accessibility:** Yes, improves accurate reading of the Locale Switcher control for assistive technologies.

---
*PR created automatically by Jules for task [7271023342052313910](https://jules.google.com/task/7271023342052313910) started by @daribock*