### PR TITLE
🎨 Palette: Add focus states to mobile menu button

### DIFF
--- a/components/layout/nav/header/header-mobile-menu.tsx
+++ b/components/layout/nav/header/header-mobile-menu.tsx
@@ -22,7 +22,7 @@ export const HeaderMobileMenu = ({ nav }: HeaderMobileMenuProps) => {
         aria-label={isOpen ? 'Close Menu' : 'Open Menu'}
         aria-expanded={isOpen}
         aria-controls="mobile-nav-menu"
-        className="relative z-20 -m-2.5 -mr-4 cursor-pointer p-2.5 lg:hidden h-12 w-12 flex items-center justify-center"
+        className="relative z-20 -m-2.5 -mr-4 cursor-pointer p-2.5 lg:hidden h-12 w-12 flex items-center justify-center focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm"
       >
         <Menu
           className={cn(


### PR DESCRIPTION
💡 What: Added `focus-visible` Tailwind classes (`focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden rounded-sm`) to the mobile menu `<button>` toggler in `components/layout/nav/header/header-mobile-menu.tsx`.
🎯 Why: Ensure the main interactive toggler for the mobile navigation has clear, visible focus states to support keyboard navigation.
📸 Before/After: Not applicable (invisible until focused via keyboard).
♿ Accessibility: Improves keyboard accessibility by surfacing the focus ring.

---
*PR created automatically by Jules for task [15442205285895675717](https://jules.google.com/task/15442205285895675717) started by @daribock*