### PR TITLE
⚡ Bolt: Optimize TinaCMS sequential fetching

### DIFF
--- a/app/[locale]/[...urlSegments]/page.tsx
+++ b/app/[locale]/[...urlSegments]/page.tsx
@@ -119,7 +119,8 @@ export default async function Page({
 }
 
 export async function generateStaticParams() {
-  let pages = await client.queries.pageConnection();
+  // ⚡ Bolt: Increase batch size to 100 to reduce N+1 queries during static param generation
+  let pages = await client.queries.pageConnection({ first: 100 });
   const allPages = pages;
 
   if (!allPages.data.pageConnection.edges) {
@@ -128,6 +129,7 @@ export async function generateStaticParams() {
 
   while (pages.data.pageConnection.pageInfo.hasNextPage) {
     pages = await client.queries.pageConnection({
+      first: 100,
       after: pages.data.pageConnection.pageInfo.endCursor,
     });
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -23,11 +23,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // Add all content pages
   try {
-    let pages = await client.queries.pageConnection();
+    // ⚡ Bolt: Increase batch size to 100 to reduce N+1 queries during sitemap generation
+    let pages = await client.queries.pageConnection({ first: 100 });
     const pageEdges = [...(pages.data.pageConnection.edges ?? [])];
 
     while (pages.data.pageConnection.pageInfo.hasNextPage) {
       pages = await client.queries.pageConnection({
+        first: 100,
         after: pages.data.pageConnection.pageInfo.endCursor,
       });
       if (!pages.data.pageConnection.edges) break;


### PR DESCRIPTION
### 💡 What:
Increased the batch size for `pageConnection` queries to 100 by explicitly passing `{ first: 100 }` in both `app/sitemap.ts` and the `generateStaticParams` function in `app/[locale]/[...urlSegments]/page.tsx`.

### 🎯 Why:
By default, paginated queries in TinaCMS might retrieve a small amount of edges per request. For full-site operations like generating static parameters or sitemaps, this results in an N+1 query problem, forcing the system to perform many sequential network roundtrips to retrieve all pages.

### 📊 Impact:
Significantly reduces the number of sequential network requests made during the static generation phase (`next build`) and when dynamically generating the sitemap. This results in faster build times and reduced load on the TinaCMS API.

### 🔬 Measurement:
Run `NODE_OPTIONS="--max-old-space-size=4096" pnpm run build:local` and observe the reduced build time and fewer network roundtrips compared to before the patch. Verify by examining the generated network logs or build speed on large datasets.

---
*PR created automatically by Jules for task [6041116746253299625](https://jules.google.com/task/6041116746253299625) started by @daribock*